### PR TITLE
fix "missing cookie header" error

### DIFF
--- a/packages/universal-cookie-express/src/index.js
+++ b/packages/universal-cookie-express/src/index.js
@@ -2,7 +2,7 @@ import Cookies from 'universal-cookie';
 
 export default function universalCookieMiddleware() {
   return function(req, res, next) {
-    req.universalCookies = new Cookies(req.headers.cookie, {
+    req.universalCookies = new Cookies(req.headers.cookie || '', {
       onSet(name, value, options) {
         if (!req.cookie || res.headersSent) {
           return;


### PR DESCRIPTION
The middleware throws an error (`Missing the cookie header or object`) if the client didn't sent a cookie header. Which in turn breaks the route chain and cause most express servers to just respond with an http 500.