### PR TITLE
Fix example in universal-cookie-express README

### DIFF
--- a/packages/universal-cookie-express/README.md
+++ b/packages/universal-cookie-express/README.md
@@ -35,6 +35,6 @@ app
   .use(cookiesMiddleware())
   .use(function(req, res) {
     // get the user cookies using universal-cookie
-    req.universalCookie.get('myCat')
+    req.universalCookies.get('myCat')
   });
 ```


### PR DESCRIPTION
Just a small doc fix.  The README's example shows `universalCookie`, but the library adds `universalCookies` in the plural to `req`.

https://github.com/reactivestack/cookies/blob/master/packages/universal-cookie-express/src/index.js#L5