### PR TITLE
Always run onSet and onRemove regardless of environment

### DIFF
--- a/packages/react-cookie/src/CookiesProvider.js
+++ b/packages/react-cookie/src/CookiesProvider.js
@@ -5,7 +5,8 @@ import { isNode } from 'universal-cookie/lib/utils';
 
 export default class CookiesProvider extends Component {
   static propTypes = {
-    children: node
+    children: node,
+    cookies: instanceOf(Cookies)
   };
 
   static childContextTypes = {
@@ -15,7 +16,7 @@ export default class CookiesProvider extends Component {
   constructor(props) {
     super(props);
 
-    if (isNode()) {
+    if (props.cookies) {
       this.cookies = props.cookies;
     } else {
       this.cookies = new Cookies();

--- a/packages/universal-cookie/src/Cookies.js
+++ b/packages/universal-cookie/src/Cookies.js
@@ -12,11 +12,11 @@ export default class Cookies {
       } else {
         throw new Error('Missing the cookie header or object');
       }
-
-      this.hooks = hooks;
     } else if (cookies) {
       throw new Error('The browser should not provide the cookies');
     }
+
+    this.hooks = hooks;
   }
 
   get(name, options = {}) {
@@ -40,12 +40,12 @@ export default class Cookies {
       value = JSON.stringify(value);
     }
 
+    if (this.hooks && this.hooks.onSet) {
+      this.hooks.onSet(name, value, options);
+    }
+
     if (isNode()) {
       this.cookies[name] = value;
-
-      if (this.hooks && this.hooks.onSet) {
-        this.hooks.onSet(name, value, options);
-      }
     } else {
       document.cookie = cookie.serialize(name, value, options);
     }
@@ -57,12 +57,12 @@ export default class Cookies {
       maxAge: 0
     }));
 
+    if (this.hooks && this.hooks.onRemove) {
+      this.hooks.onRemove(name, finalOptions);
+    }
+
     if (isNode()) {
       delete this.cookies[name];
-
-      if (this.hooks && this.hooks.onSet) {
-        this.hooks.onRemove(name, finalOptions);
-      }
     } else {
       document.cookie = cookie.serialize(name, '', finalOptions);
     }


### PR DESCRIPTION
This partly includes the fix from https://github.com/reactivestack/cookies/pull/94 without the update to the tests, so ideally we should merge that in first and rebase this branch.

I would like to run onSet and onRemove irrespective of the environment, I couldn't think of any reason to only run it on node since the browser does not provide hooks to support hook.

Also note that the onSet/onRemove is before setting the cookie, this is to allow the onSet to manipulate the `options` which is passed by reference. It shouldn't cause too much issue of existing usages however it may be considered as a breaking change if a usage of onSet is also subsequently has a reference to the cookies instance and is querying it.