### PR TITLE
value with double quotation should be JSON.parse automatically

### DIFF
--- a/packages/universal-cookie/src/Cookies.js
+++ b/packages/universal-cookie/src/Cookies.js
@@ -72,7 +72,7 @@ export default class Cookies {
 function isParsingCookie(value, doNotParse) {
   if (typeof doNotParse === 'undefined') {
     // We guess if the cookie start with { or [, it has been serialized
-    doNotParse = !value || (value[0] !== '{' && value[0] !== '[');
+    doNotParse = !value || (value[0] !== '{' && value[0] !== '[') && value[0] !== '"';
   }
 
   return !doNotParse;

--- a/packages/universal-cookie/src/__tests__/Cookies-test.js
+++ b/packages/universal-cookie/src/__tests__/Cookies-test.js
@@ -25,6 +25,14 @@ describe('Cookies', () => {
 
         expect(cookiesContext.get('testingCookie')).toBe('yes');
       });
+
+      it('read the double quotations value', () => {
+        const cookiesContext = new Cookies();
+
+        document.cookie = 'testingCookie="yes"';
+
+        expect(cookiesContext.get('testingCookie')).toBe('yes');
+      });
     });
 
     describe('getAll([options])', () => {


### PR DESCRIPTION
Since string is a standard JSON type start with `"`, so we can automatically parse it.