### PR TITLE
[Fix] Type error in Cookies class constructor

### DIFF
--- a/packages/universal-cookie/src/Cookies.js
+++ b/packages/universal-cookie/src/Cookies.js
@@ -6,7 +6,7 @@ export default class Cookies {
   constructor(cookies, hooks) {
     if (typeof cookies === 'string') {
       this.cookies = cookie.parse(cookies);
-    } else if (typeof cookies === 'object') {
+    } else if (cookies != null && typeof cookies === 'object') {
       this.cookies = cookies;
     } else {
       this.cookies = {};


### PR DESCRIPTION
`typeof null === 'object'` which can result in a broken state.