### PR TITLE
Be able to change the property name of request

### DIFF
--- a/packages/universal-cookie-express/src/index.js
+++ b/packages/universal-cookie-express/src/index.js
@@ -1,8 +1,8 @@
 import Cookies from 'universal-cookie';
 
-export default function universalCookieMiddleware() {
+export default function universalCookieMiddleware(cookiePropName = 'universalCookies') {
   return function(req, res, next) {
-    req.universalCookies = new Cookies(req.headers.cookie || '', {
+    req[cookiePropName] = new Cookies(req.headers.cookie || '', {
       onSet(name, value, options) {
         if (!res.cookie || res.headersSent) {
           return;


### PR DESCRIPTION
Instead of using `req.universakCookies` I'd like to be able to use `req.cookies`.

So, I could use it like that:

```js
app.use(universalCookieMiddleware('cookies'));

app.get('/', (req, res) => {
req.cookies.get('foo'); // instead of req.universalCookies.get('foo')
});
```