### PR TITLE
116 added extra loop for removing the cookies that do not exists in the browser anymore

### DIFF
--- a/packages/react-cookie/src/__tests__/withCookies-test.js
+++ b/packages/react-cookie/src/__tests__/withCookies-test.js
@@ -38,6 +38,10 @@ describe('withCookies(Component)', () => {
 
   describe('on the server', () => {
     it('provides the cookies', () => {
+      document.__defineGetter__('cookie', function() {
+        return undefined;
+      });
+
       const cookies = new Cookies('test="big fat cat"');
       const Component = withCookies(TestComponent);
 

--- a/packages/universal-cookie/src/Cookies.js
+++ b/packages/universal-cookie/src/Cookies.js
@@ -27,6 +27,13 @@ export default class Cookies {
     for (let name in newCookies) {
       this.cookies[name] = newCookies[name];
     }
+
+    // check for manually deleted cookies
+    for (let name in this.cookies) {
+      if (newCookies[name] === undefined) {
+        delete this.cookies[name];
+      }
+    }
   }
 
   get(name, options = {}) {

--- a/packages/universal-cookie/src/__tests__/Cookies-test.js
+++ b/packages/universal-cookie/src/__tests__/Cookies-test.js
@@ -9,6 +9,10 @@ describe('Cookies', () => {
   describe('constructor()', () => {
     it('read a cookie object', () => {
       const cookiesValues = { test: 'meow' };
+
+      // add cookie to document to match browser cookies when passed to constructor
+      document.cookie = 'test=' + cookiesValues.test;
+
       const cookies = new Cookies(cookiesValues);
       expect(cookies.get('test')).toBe(cookiesValues.test);
     });
@@ -17,6 +21,9 @@ describe('Cookies', () => {
       const cookieValue = 'meow';
       const cookiesValues = 'test=' + cookieValue;
       const cookies = new Cookies(cookiesValues);
+
+      // add cookie to document to match browser cookies when passed to constructor
+      document.cookie = cookiesValues;
 
       expect(cookies.get('test')).toBe(cookieValue);
     });
@@ -47,7 +54,7 @@ describe('Cookies', () => {
     });
   });
 
-  describe('get(name, [optioons])', () => {
+  describe('get(name, [options])', () => {
     it('read the real-time value', () => {
       const cookieValue = 'rreow';
       const cookies = new Cookies();
@@ -63,16 +70,27 @@ describe('Cookies', () => {
       const cookieValue = 'boom';
       const cookies = new Cookies({ test: '"' + cookieValue + '"' });
 
+      // add cookie to document to match browser cookies when passed to constructor
+      document.cookie = 'test=' + cookieValue;
+
       expect(cookies.get('test')).toBe(cookieValue);
     });
 
     it('parse serialized object', () => {
       const cookies = new Cookies({ test: '{}' });
+
+      // add cookie to document to match browser cookies when passed to constructor
+      document.cookie = 'test=' + JSON.stringify({});
+
       expect(typeof cookies.get('test')).toBe('object');
     });
 
     it('parse serialized array', () => {
       const cookies = new Cookies({ test: '[]' });
+
+      // add cookie to document to match browser cookies when passed to constructor
+      document.cookie = 'test=' + JSON.stringify([]);
+
       const result = cookies.get('test');
 
       expect(typeof result).toBe('object');


### PR DESCRIPTION
added extra loop for removing the cookies that do not exists in the browser anymore (due to manual deletion, 3rd party, ...) + updated tests with document.cookie values where needed. 

**Still need to fix one test in the react-cookie package though.**