### PR TITLE
Upgrade hoist-non-react-statics to 2.x

### DIFF
--- a/packages/react-cookie/package.json
+++ b/packages/react-cookie/package.json
@@ -24,7 +24,7 @@
     "build": "rimraf lib && babel src -d lib --ignore __tests__"
   },
   "dependencies": {
-    "hoist-non-react-statics": "^1.2.0",
+    "hoist-non-react-statics": "^2.3.1",
     "prop-types": "^15.0.0",
     "universal-cookie": "^2.1.2"
   },


### PR DESCRIPTION
When running `duplicate-package-checker` to lean out the bundle on the app I'm working on, I got a hit on `hoist-non-react-statics`. All my other dependencies (`react-apollo`, `react-redux`, `react-router`, etc.) requested  `hoist-non-react-statics` `2.x`.

Glancing at the `hoist-non-react-statics` release notes, this should be a non-breaking change.