### PR TITLE
Update the documentation for maxAge

### DIFF
--- a/packages/universal-cookie/README.md
+++ b/packages/universal-cookie/README.md
@@ -54,7 +54,7 @@ Remove a cookie
 - options (object): Support all the cookie options from RFC 6265
   - path (string): cookie path, use `/` as the path if you want your cookie to be accessible on all pages
   - expires (Date): absolute expiration date for the cookie
-  - maxAge (number): relative max age of the cookie from when the client receives it in second
+  - maxAge (number): relative max age of the cookie from when the client receives it in **[milliseconds](https://github.com/jshttp/cookie#maxage)**
   - domain (string): domain for the cookie (sub.domain.com or .allsubdomains.com)
   - secure (boolean): Is only accessible through HTTPS?
   - httpOnly (boolean): Is only the server can access the cookie?


### PR DESCRIPTION
The underlying cookie object uses milliseconds, not seconds for maxAge