### PR TITLE
Include typings during react-cookie build

### DIFF
--- a/packages/react-cookie/package.json
+++ b/packages/react-cookie/package.json
@@ -22,7 +22,7 @@
   "author": "Benoit Tremblay <benoit@reactivestack.com>",
   "license": "MIT",
   "scripts": {
-    "build": "rimraf lib && babel src -d lib --ignore __tests__"
+    "build": "rimraf lib && babel src -D -d lib --ignore __tests__"
   },
   "dependencies": {
     "hoist-non-react-statics": "^2.3.1",


### PR DESCRIPTION
Add -D (--copy-files) flag to babel build to include
non-compilable files. Currently, only the index.d.ts
typings file is the only non-compilable file.

Fixes #141