### PR TITLE
Add Typescript definitions for Cookies constructor

### DIFF
--- a/packages/react-cookie/index.d.ts
+++ b/packages/react-cookie/index.d.ts
@@ -3,6 +3,13 @@ import * as React from 'react';
 export type Cookie = string;
 
 export class Cookies {
+    constructor(
+        cookieHeader?: string | object | null,
+        hooks?: {
+            onSet: (name: string, value: string, options?: ReactCookieSetOptions) => void;
+            onRemove: (name: string, options?: ReactCookieRemoveOptions) => void;
+        },
+    );
     get: (key: string, options?: ReactCookieGetOptions) => Cookie | undefined;
     getAll: (options?: ReactCookieGetAllOptions) => Cookie[];
     set(name: string, value: string, options?: ReactCookieSetOptions): void;


### PR DESCRIPTION
Currently, I am getting a Typescript error when instantiating `Cookies` with a headers string.

For example, given:
```
new Cookies(req.headers.cookie);
```

Typescript will throw:
```
error TS2554: Expected 0 arguments, but got 1.
```

This change just types the constructor to support the cookies header, as well as the optional hooks argument. I based the typings off of what I found in the [current source](https://github.com/reactivestack/cookies/blob/master/packages/universal-cookie/src/Cookies.js#L6-L10) of `universal-cookies`.

I realize that you are not using Typescript, so maybe a couple other community members can test out my fork and verify it does not create any issues before proceeding?

cc @sugarpac @franklixuefei @Guymestef