### PR TITLE
Fix undefined name of component

### DIFF
--- a/packages/react-cookie/src/withCookies.js
+++ b/packages/react-cookie/src/withCookies.js
@@ -5,8 +5,8 @@ import hoistStatics from 'hoist-non-react-statics';
 
 export default function withCookies(WrapperComponent) {
   class Wrapper extends Component {
-    static displayName = `withCookies(${Component.displayName ||
-      Component.name})`;
+    static displayName = `withCookies(${WrapperComponent.displayName ||
+      WrapperComponent.name})`;
     static WrapperComponent = WrapperComponent;
 
     static propTypes = {


### PR DESCRIPTION
Fix minor misspel, `Component` is `React.Component` now, should use name of `WrapperComponent` in `displayName`