### PR TITLE
fix(typings - no need for optionals)

### DIFF
--- a/packages/react-cookie/src/types.ts
+++ b/packages/react-cookie/src/types.ts
@@ -2,8 +2,8 @@ import Cookies from 'universal-cookie';
 import { Cookie } from 'universal-cookie';
 
 export type ReactCookieProps = {
-    cookies?: Cookies,
-    allCookies?: { [name: string]: Cookie }
+    cookies: Cookies,
+    allCookies: { [name: string]: Cookie }
     children?: any,
     ref?: React.RefObject<{}>
 };

--- a/packages/react-cookie/src/withCookies.tsx
+++ b/packages/react-cookie/src/withCookies.tsx
@@ -33,6 +33,7 @@ export default function withCookies<T>(WrapperComponent: React.ComponentType<T &
     unlisten() {
       if (this.cookies) {
         this.cookies.removeChangeListener(this.onChange);
+        this.cookies = undefined;
       }
     }
 


### PR DESCRIPTION
from the actual implementation, `cookies` and `allCookies` cannot be undefined, thus optional is unneeded.