### PR TITLE
Fix/lerna build

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "karma-sourcemap-loader": "^0.3.7",
     "karma-spec-reporter": "^0.0.32",
     "karma-webpack": "^3.0.0",
-    "lerna": "3.0.4",
+    "lerna": "3.6.0",
     "prettier": "^1.14.2",
     "rimraf": "^2.6.1",
     "rollup": "^0.64.1",

--- a/packages/react-cookie/src/withCookies.tsx
+++ b/packages/react-cookie/src/withCookies.tsx
@@ -50,7 +50,7 @@ export default function withCookies<T>(
       const allCookies = cookies.getAll();
       return (
         <WrapperComponent
-          {...restProps}
+          {...restProps as T}
           ref={forwardedRef}
           cookies={cookies}
           allCookies={allCookies}


### PR DESCRIPTION
This PR should resolve #199 and has a little fix for `tsc` command, that was failing as well, after Lerna build started running again.

I've checked Lerna releases for backwards incompatibilities and haven't found one, so I guess it will not break anything here.