### PR TITLE
Support explicit None value for sameSite attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ##vNEXT
 
+- `universal-cookie`: Add support for explicit `None` value on `sameSite` attribute
 ##v4.0.1
 
 - Upgrade dependencies to last versions

--- a/packages/react-cookie/README.md
+++ b/packages/react-cookie/README.md
@@ -84,7 +84,7 @@ Set a cookie value
   - domain (string): domain for the cookie (sub.domain.com or .allsubdomains.com)
   - secure (boolean): Is only accessible through HTTPS?
   - httpOnly (boolean): Is only the server can access the cookie?
-  - sameSite (boolean|lax|strict): Strict or Lax enforcement
+  - sameSite (boolean|none|lax|strict): Strict or Lax enforcement
 
 ### `removeCookie(name, [options])`
 
@@ -98,7 +98,7 @@ Remove a cookie
   - domain (string): domain for the cookie (sub.domain.com or .allsubdomains.com)
   - secure (boolean): Is only accessible through HTTPS?
   - httpOnly (boolean): Is only the server can access the cookie?
-  - sameSite (boolean|lax|strict): Strict or Lax enforcement
+  - sameSite (boolean|none|lax|strict): Strict or Lax enforcement
 
 ## `withCookies(Component)`
 
@@ -147,7 +147,7 @@ Set a cookie value
   - domain (string): domain for the cookie (sub.domain.com or .allsubdomains.com)
   - secure (boolean): Is only accessible through HTTPS?
   - httpOnly (boolean): Is only the server can access the cookie?
-  - sameSite (boolean|lax|strict): Strict or Lax enforcement
+  - sameSite (boolean|none|lax|strict): Strict or Lax enforcement
 
 ### `remove(name, [options])`
 
@@ -161,7 +161,7 @@ Remove a cookie
   - domain (string): domain for the cookie (sub.domain.com or .allsubdomains.com)
   - secure (boolean): Is only accessible through HTTPS?
   - httpOnly (boolean): Is only the server can access the cookie?
-  - sameSite (boolean|lax|strict): Strict or Lax enforcement
+  - sameSite (boolean|none|lax|strict): Strict or Lax enforcement
 
 ## Simple Example with React hooks
 

--- a/packages/universal-cookie/README.md
+++ b/packages/universal-cookie/README.md
@@ -53,7 +53,7 @@ Set a cookie value
   - domain (string): domain for the cookie (sub.domain.com or .allsubdomains.com)
   - secure (boolean): Is only accessible through HTTPS?
   - httpOnly (boolean): Is only the server can access the cookie?
-  - sameSite (boolean|lax|strict): Strict or Lax enforcement
+  - sameSite (boolean|none|lax|strict): Strict or Lax enforcement
 
 ### `remove(name, [options])`
 Remove a cookie
@@ -65,7 +65,7 @@ Remove a cookie
   - domain (string): domain for the cookie (sub.domain.com or .allsubdomains.com)
   - secure (boolean): Is only accessible through HTTPS?
   - httpOnly (boolean): Is only the server can access the cookie?
-  - sameSite (boolean|lax|strict): Strict or Lax enforcement
+  - sameSite (boolean|none|lax|strict): Strict or Lax enforcement
 
 ### `addChangeListener(callback)`
 Add a listener to when a cookie is set or removed.

--- a/packages/universal-cookie/src/types.ts
+++ b/packages/universal-cookie/src/types.ts
@@ -11,7 +11,7 @@ export interface CookieSetOptions {
   domain?: string;
   secure?: boolean;
   httpOnly?: boolean;
-  sameSite?: boolean | 'lax' | 'strict';
+  sameSite?: boolean | 'none' | 'lax' | 'strict';
 }
 export interface CookieChangeOptions {
   name: string;


### PR DESCRIPTION
The latest draft of [RFC6265bis](https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03) introduces an explicit `None` value for the `SameSite` attribute. This change adds it as a valid option in `CookieSetOptions`.

For context, as of Chrome 80 the intention is to treat cookies without a `SameSite` attribute as if they were `SameSite=Lax` by default. Sites that want a cookie accessible in a third-party context must specify both `SameSite=None` and `Secure` on their cookies. See: https://web.dev/samesite-cookies-explained for additional context.