### PR TITLE
Remove httpOnly from this library

### DIFF
--- a/packages/react-cookie/README.md
+++ b/packages/react-cookie/README.md
@@ -83,7 +83,6 @@ Set a cookie value
   - maxAge (number): relative max age of the cookie from when the client receives it in second
   - domain (string): domain for the cookie (sub.domain.com or .allsubdomains.com)
   - secure (boolean): Is only accessible through HTTPS?
-  - httpOnly (boolean): Is only the server can access the cookie?
   - sameSite (boolean|none|lax|strict): Strict or Lax enforcement
 
 ### `removeCookie(name, [options])`
@@ -97,7 +96,6 @@ Remove a cookie
   - maxAge (number): relative max age of the cookie from when the client receives it in second
   - domain (string): domain for the cookie (sub.domain.com or .allsubdomains.com)
   - secure (boolean): Is only accessible through HTTPS?
-  - httpOnly (boolean): Is only the server can access the cookie?
   - sameSite (boolean|none|lax|strict): Strict or Lax enforcement
 
 ## `withCookies(Component)`
@@ -146,7 +144,6 @@ Set a cookie value
   - maxAge (number): relative max age of the cookie from when the client receives it in second
   - domain (string): domain for the cookie (sub.domain.com or .allsubdomains.com)
   - secure (boolean): Is only accessible through HTTPS?
-  - httpOnly (boolean): Is only the server can access the cookie?
   - sameSite (boolean|none|lax|strict): Strict or Lax enforcement
 
 ### `remove(name, [options])`
@@ -160,7 +157,6 @@ Remove a cookie
   - maxAge (number): relative max age of the cookie from when the client receives it in second
   - domain (string): domain for the cookie (sub.domain.com or .allsubdomains.com)
   - secure (boolean): Is only accessible through HTTPS?
-  - httpOnly (boolean): Is only the server can access the cookie?
   - sameSite (boolean|none|lax|strict): Strict or Lax enforcement
 
 ## Simple Example with React hooks

--- a/packages/universal-cookie/README.md
+++ b/packages/universal-cookie/README.md
@@ -52,7 +52,6 @@ Set a cookie value
   - maxAge (number): relative max age of the cookie from when the client receives it in second
   - domain (string): domain for the cookie (sub.domain.com or .allsubdomains.com)
   - secure (boolean): Is only accessible through HTTPS?
-  - httpOnly (boolean): Is only the server can access the cookie?
   - sameSite (boolean|none|lax|strict): Strict or Lax enforcement
 
 ### `remove(name, [options])`
@@ -64,7 +63,6 @@ Remove a cookie
   - maxAge (number): relative max age of the cookie from when the client receives it in second
   - domain (string): domain for the cookie (sub.domain.com or .allsubdomains.com)
   - secure (boolean): Is only accessible through HTTPS?
-  - httpOnly (boolean): Is only the server can access the cookie?
   - sameSite (boolean|none|lax|strict): Strict or Lax enforcement
 
 ### `addChangeListener(callback)`

--- a/packages/universal-cookie/src/types.ts
+++ b/packages/universal-cookie/src/types.ts
@@ -10,7 +10,6 @@ export interface CookieSetOptions {
   maxAge?: number;
   domain?: string;
   secure?: boolean;
-  httpOnly?: boolean;
   sameSite?: boolean | 'none' | 'lax' | 'strict';
 }
 export interface CookieChangeOptions {


### PR DESCRIPTION
Based on this comment:
https://github.com/reactivestack/cookies/issues/180#issuecomment-441851712

There's no way to create or modify an httpOnly cookie from the client
side. The fact that this option is available in `setCookie` is very
deceptive. The documentation makes it sound like you could set an
httpOnly cookie on the client side, to be sent with all future HTTP
requests.

Since there's no way to create an httpOnly cookie on the client side, we
can simply remove it from the documentation and code altogether.