### PR TITLE
allow passing options to cookie.parse

### DIFF
--- a/packages/universal-cookie/src/Cookies.ts
+++ b/packages/universal-cookie/src/Cookies.ts
@@ -1,13 +1,13 @@
 import * as cookie from 'cookie';
-
-import { parseCookies, readCookie, hasDocumentCookie } from './utils';
 import {
   Cookie,
-  CookieGetOptions,
-  CookieSetOptions,
   CookieChangeListener,
-  CookieChangeOptions
+  CookieChangeOptions,
+  CookieGetOptions,
+  CookieParseOptions,
+  CookieSetOptions
 } from './types';
+import { hasDocumentCookie, parseCookies, readCookie } from './utils';
 
 // We can't please Rollup and TypeScript at the same time
 // Only way to make both of them work
@@ -19,20 +19,20 @@ export default class Cookies {
 
   private HAS_DOCUMENT_COOKIE: boolean = false;
 
-  constructor(cookies?: string | object | null) {
-    this.cookies = parseCookies(cookies);
+  constructor(cookies?: string | object | null, options?: CookieParseOptions) {
+    this.cookies = parseCookies(cookies, options);
 
     new Promise(() => {
       this.HAS_DOCUMENT_COOKIE = hasDocumentCookie();
     }).catch(() => {});
   }
 
-  private _updateBrowserValues() {
+  private _updateBrowserValues(parseOptions?: CookieParseOptions) {
     if (!this.HAS_DOCUMENT_COOKIE) {
       return;
     }
 
-    this.cookies = cookie.parse(document.cookie);
+    this.cookies = cookie.parse(document.cookie, parseOptions);
   }
 
   private _emitChange(params: CookieChangeOptions) {
@@ -43,15 +43,22 @@ export default class Cookies {
 
   public get(name: string, options?: CookieGetOptions): any;
   public get<T>(name: string, options?: CookieGetOptions): T;
-  public get(name: string, options: CookieGetOptions = {}) {
-    this._updateBrowserValues();
+  public get(
+    name: string,
+    options: CookieGetOptions = {},
+    parseOptions?: CookieParseOptions
+  ) {
+    this._updateBrowserValues(parseOptions);
     return readCookie(this.cookies[name], options);
   }
 
   public getAll(options?: CookieGetOptions): any;
   public getAll<T>(options?: CookieGetOptions): T;
-  public getAll(options: CookieGetOptions = {}) {
-    this._updateBrowserValues();
+  public getAll(
+    options: CookieGetOptions = {},
+    parseOptions?: CookieParseOptions
+  ) {
+    this._updateBrowserValues(parseOptions);
     const result: { [name: string]: any } = {};
 
     for (let name in this.cookies) {

--- a/packages/universal-cookie/src/types.ts
+++ b/packages/universal-cookie/src/types.ts
@@ -19,4 +19,8 @@ export interface CookieChangeOptions {
   options?: CookieSetOptions;
 }
 
+export interface CookieParseOptions {
+  decode: (value: string) => string;
+}
+
 export type CookieChangeListener = (options: CookieChangeOptions) => void;

--- a/packages/universal-cookie/src/utils.ts
+++ b/packages/universal-cookie/src/utils.ts
@@ -1,5 +1,5 @@
 import * as cookie from 'cookie';
-import { Cookie, CookieGetOptions } from './types';
+import { Cookie, CookieGetOptions, CookieParseOptions } from './types';
 
 export function hasDocumentCookie() {
   // JSDOM does not support changing cookies, disable it for tests
@@ -33,9 +33,12 @@ export function cleanCookies() {
   });
 }
 
-export function parseCookies(cookies?: string | object | null) {
+export function parseCookies(
+  cookies?: string | object | null,
+  options?: CookieParseOptions
+) {
   if (typeof cookies === 'string') {
-    return cookie.parse(cookies);
+    return cookie.parse(cookies, options);
   } else if (typeof cookies === 'object' && cookies !== null) {
     return cookies;
   } else {


### PR DESCRIPTION
universal-cookie's use of `cookie.parse` without passing any options leads to cookies always being decoded, which is an issue for scenarios where cookies only need to be forwarded untouched