### PR TITLE
add optional encode parameter to CookieSetOptions

### DIFF
--- a/packages/universal-cookie/src/types.ts
+++ b/packages/universal-cookie/src/types.ts
@@ -12,6 +12,7 @@ export interface CookieSetOptions {
   secure?: boolean;
   httpOnly?: boolean;
   sameSite?: boolean | 'none' | 'lax' | 'strict';
+  encode?: (value: string) => string;
 }
 export interface CookieChangeOptions {
   name: string;


### PR DESCRIPTION
encode is a valid option for cookie.serialize