### PR TITLE
[FEATURE] Expose Cookie Context

### DIFF
--- a/packages/react-cookie/src/CookiesContext.ts
+++ b/packages/react-cookie/src/CookiesContext.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Cookies from './Cookies';
 
-export const CookiesContext = React.createContext(new Cookies());
+const CookiesContext = React.createContext(new Cookies());
 
 export const { Provider, Consumer } = CookiesContext;
 export default CookiesContext;

--- a/packages/react-cookie/src/CookiesContext.ts
+++ b/packages/react-cookie/src/CookiesContext.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Cookies from './Cookies';
 
-const CookiesContext = React.createContext(new Cookies());
+export const CookiesContext = React.createContext(new Cookies());
 
 export const { Provider, Consumer } = CookiesContext;
 export default CookiesContext;

--- a/packages/react-cookie/src/index.ts
+++ b/packages/react-cookie/src/index.ts
@@ -1,5 +1,5 @@
 export { default as Cookies } from './Cookies';
-export { CookiesContext } from './CookiesContext';
+export { default as CookiesContext } from './CookiesContext';
 export { default as CookiesProvider } from './CookiesProvider';
 export { default as withCookies } from './withCookies';
 export { default as useCookies } from './useCookies';

--- a/packages/react-cookie/src/index.ts
+++ b/packages/react-cookie/src/index.ts
@@ -1,4 +1,5 @@
 export { default as Cookies } from './Cookies';
+export { CookiesContext } from './CookiesContext';
 export { default as CookiesProvider } from './CookiesProvider';
 export { default as withCookies } from './withCookies';
 export { default as useCookies } from './useCookies';


### PR DESCRIPTION
Hi I have a case where I need to access the plain Cookie object using react hooks. I just realized that the the CookieContext is not exposed publicly so I can't use `useContext(CookieContext)` in my code. 

This PR is only exposing that cookie context