### PR TITLE
check navigator.cookieEnabled

### DIFF
--- a/packages/universal-cookie/src/utils.ts
+++ b/packages/universal-cookie/src/utils.ts
@@ -3,12 +3,22 @@ import { Cookie, CookieGetOptions } from './types';
 
 export function hasDocumentCookie() {
   // JSDOM does not support changing cookies, disable it for tests
-  if (isJsDom()) {
+  if (isJsDom() || cookieDisabledBySettings()) {
     return false;
   }
 
   // Can we get/set cookies on document.cookie?
   return typeof document === 'object' && typeof document.cookie === 'string';
+}
+
+function cookieDisabledBySettings() {
+  if (typeof navigator !== 'object') {
+      return false;
+  }
+
+  // user can disable cookie for site
+  // in browser settings
+  return navigator.cookieEnabled === false;
 }
 
 function isJsDom(): boolean {


### PR DESCRIPTION
now users can disable cookie in browser setting
In this case you can access to document.cookie, but canot rewrite it

for example
```
document.cookie = "test=cookie"
console.log(document.cookie) // "" - empty string
```

therefore  
```
  private _updateBrowserValues() {
    if (!this.HAS_DOCUMENT_COOKIE) {
      return;
    }

    this.cookies = cookie.parse(document.cookie);
  }
```
_updateBrowserValues called on getAll always reset cookie to empty object.