### PR TITLE
Add ability to trigger change listeners manually

### DIFF
--- a/packages/universal-cookie/src/Cookies.ts
+++ b/packages/universal-cookie/src/Cookies.ts
@@ -108,4 +108,8 @@ export default class Cookies {
       this.changeListeners.splice(idx, 1);
     }
   }
+  
+  public triggerChangeListeners(params: CookieChangeOptions) {
+    this._emitChange(params);
+  }
 }


### PR DESCRIPTION
Hi,

I've implemented some code which will fire events across browser windows. In my case, I need this so I can act upon the removal of the session cookie (i.e. logging out).

For me to do this, I need to be able to trigger the change listeners manually (the variables and function are private).