### PR TITLE
fix(universal-cookie-koa): convert maxAge seconds to ms

### DIFF
--- a/packages/universal-cookie-koa/src/index.ts
+++ b/packages/universal-cookie-koa/src/index.ts
@@ -11,7 +11,13 @@ export default function universalCookieMiddleware() {
         if (change.value === undefined) {
           ctx.cookies.set(change.name, null);
         } else {
-          ctx.cookies.set(change.name, change.value, change.options);
+          const koaOpt = (<any>Object).assign({}, change.options);
+          if (koaOpt.maxAge && change.options && change.options.maxAge) {
+            // the standard for maxAge is seconds but koa uses milliseconds
+            koaOpt.maxAge = change.options.maxAge * 1000;
+          };
+
+          ctx.cookies.set(change.name, change.value, koaOpt);
         }
       }
     );


### PR DESCRIPTION
Koa uses **milliseconds** for the `maxAge` option value: [koa docs](https://github.com/koajs/koa/blob/7deedb235274223f1b9da46dee296545b23598de/docs/api/context.md#ctxcookiessetname-value-options) but the value provided for `maxAge` in universal-cookie is **seconds**.

I made the required changes based on the [express implementation](https://github.com/reactivestack/cookies/blob/master/packages/universal-cookie-express/src/index.ts#L15).