### PR TITLE
Fix esmodule build in react-cookie

### DIFF
--- a/packages/react-cookie/package.json
+++ b/packages/react-cookie/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@types/hoist-non-react-statics": "^3.0.1",
     "hoist-non-react-statics": "^3.0.0",
-    "universal-cookie": "^4.0.0"
+    "universal-cookie": "^4.0.4"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0",

--- a/packages/react-cookie/package.json
+++ b/packages/react-cookie/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@types/hoist-non-react-statics": "^3.0.1",
     "hoist-non-react-statics": "^3.0.0",
-    "universal-cookie": "^4.0.4"
+    "universal-cookie": "^4.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0",

--- a/packages/react-cookie/src/withCookies.tsx
+++ b/packages/react-cookie/src/withCookies.tsx
@@ -1,11 +1,9 @@
 import Cookies from 'universal-cookie';
 import * as React from 'react';
+import * as hoistStatics from 'hoist-non-react-statics';
 
 import { Consumer } from './CookiesContext';
 import { ReactCookieProps } from './types';
-
-// Only way to make function modules work with both TypeScript and Rollup
-const hoistStatics = require('hoist-non-react-statics');
 
 type Diff<T, U> = T extends U ? never : T;
 type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>;


### PR DESCRIPTION
👋 Hi friends! `react-cookie` claims to provide an [esmodule build](https://github.com/reactivestack/cookies/blob/master/packages/react-cookie/package.json#L6) but when bundling with ESM-supported bundlers, the build chokes. We hit this with [snowpack](https://www.snowpack.dev/), but I suspect the same would happen with something like webpack 5. 

```
ReferenceError: require is not defined
    at http://localhost:40020/_snowpack/pkg/react-cookie.v4.0.3.js:75:20
```
