### PR TITLE
Convert to `useLayoutEffect`

### DIFF
--- a/packages/react-cookie/src/useCookies.tsx
+++ b/packages/react-cookie/src/useCookies.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useState, useRef, useMemo } from 'react';
+import { useContext, useLayoutEffect, useState, useRef, useMemo } from 'react';
 import { Cookie, CookieSetOptions } from 'universal-cookie';
 import CookiesContext from './CookiesContext';
 
@@ -18,7 +18,7 @@ export default function useCookies(
   const [allCookies, setCookies] = useState(initialCookies);
   const previousCookiesRef = useRef(allCookies);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     function onChange() {
       const newCookies = cookies.getAll();
 


### PR DESCRIPTION
On investigating #260 I determined that the `useCookies` hook within
`react-cookie` package should call `cookies.addChangeListener` from within
`useLayoutEffect`, instead of `useEffect`.
The reason for this is that `useEffect` executes after the DOM renders, and after
any prior `useEffects`, and all `useLayoutEffects`. This means that, on initial app
load, some cookie updates can execute prior to this registration. (I observed this
in my local development based app initialization and initial effects.)
See: https://kentcdodds.com/blog/useeffect-vs-uselayouteffect#one-special-case
I don't know if this will help fix #260, but it can't hurt.