### PR TITLE
Fix return type of decoded cookies

### DIFF
--- a/packages/universal-cookie/src/types.ts
+++ b/packages/universal-cookie/src/types.ts
@@ -24,4 +24,8 @@ export interface CookieParseOptions<V = string> {
   decode: (value: string) => V;
 }
 
+export interface ParsedCookies<V = string> {
+  [key: string]: V | string
+}
+
 export type CookieChangeListener<V = string> = (options: CookieChangeOptions<V>) => void;

--- a/packages/universal-cookie/src/types.ts
+++ b/packages/universal-cookie/src/types.ts
@@ -4,7 +4,7 @@ export interface CookieGetOptions {
   doNotParse?: boolean;
 }
 
-export interface CookieSetOptions {
+export interface CookieSetOptions<V = string> {
   path?: string;
   expires?: Date;
   maxAge?: number;
@@ -12,16 +12,16 @@ export interface CookieSetOptions {
   secure?: boolean;
   httpOnly?: boolean;
   sameSite?: boolean | 'none' | 'lax' | 'strict';
-  encode?: (value: string) => string;
+  encode?: (value: V) => string;
 }
-export interface CookieChangeOptions {
+export interface CookieChangeOptions<V = string> {
   name: string;
   value?: any;
-  options?: CookieSetOptions;
+  options?: CookieSetOptions<V>;
 }
 
-export interface CookieParseOptions {
-  decode: (value: string) => string;
+export interface CookieParseOptions<V = string> {
+  decode: (value: string) => V;
 }
 
-export type CookieChangeListener = (options: CookieChangeOptions) => void;
+export type CookieChangeListener<V = string> = (options: CookieChangeOptions<V>) => void;

--- a/packages/universal-cookie/src/utils.ts
+++ b/packages/universal-cookie/src/utils.ts
@@ -1,5 +1,5 @@
 import * as cookie from 'cookie';
-import { Cookie, CookieGetOptions, CookieParseOptions } from './types';
+import { Cookie, CookieGetOptions, CookieParseOptions, ParsedCookies } from './types';
 
 export function hasDocumentCookie() {
   // Can we get/set cookies on document.cookie?
@@ -14,16 +14,16 @@ export function cleanCookies() {
   });
 }
 
-export function parseCookies(
+export function parseCookies<V = string>(
   cookies?: string | object | null,
-  options?: CookieParseOptions
+  options?: CookieParseOptions<V>
 ) {
   if (typeof cookies === 'string') {
-    return cookie.parse(cookies, options);
+    return cookie.parse(cookies, options) as ParsedCookies<V>;
   } else if (typeof cookies === 'object' && cookies !== null) {
-    return cookies;
+    return cookies as ParsedCookies<V>;
   } else {
-    return {};
+    return {} as ParsedCookies<V>;
   }
 }
 


### PR DESCRIPTION
The type of cookies was always returning string even if a custom decode function was passed into the options variable. This change allows the return type to either be the type of the return from the decode function passed into the options or string in case the decode fails.

My initial intention was to fully type the cookie.parse function, but that is actually from another package not in this repo and that package is not typescript, so I think this is the best we get for now.